### PR TITLE
plot in different colors for source items more than 9 as default in previous version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: siar
 Type: Package
 Title: Stable Isotope Analysis in R
-Version: 4.2.2
-Date: 2013-4-23
-Depends: hdrcde, coda, MASS, bayesm, mnormt, spatstat, hdrcde
+Version: 4.2.3
+Date: 2018-07-13
+Depends: hdrcde, coda, MASS, bayesm, mnormt, spatstat, hdrcde, grDevices
 Author: Andrew Parnell and Andrew Jackson
 Maintainer: Andrew Parnell <Andrew.Parnell@ucd.ie>
 Description: This package takes data on organism isotopes and fits a

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -43,6 +43,7 @@ import(hdrcde)
 import(coda)
 import(MASS)
 import(mnormt)
+import(grDevices)
 importFrom(bayesm, rdirichlet, rwishart, rmultireg)
 importFrom(spatstat, overlap.xypolygon)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -45,7 +45,7 @@ import(MASS)
 import(mnormt)
 import(grDevices)
 importFrom(bayesm, rdirichlet, rwishart, rmultireg)
-importFrom(spatstat, overlap.xypolygon)
+importFrom(spatstat.utils, overlap.xypolygon)
 
 
 

--- a/R/siarplotdata.R
+++ b/R/siarplotdata.R
@@ -1,6 +1,6 @@
 siarplotdata <-
 function (siardata, siarversion = 0, grp = 1:siardata$numgroups,
-    panel = NULL, isos = c(0, 0), leg = 1)
+    panel = NULL, isos = c(0, 0), leg = 1, color.src=NULL)
 {
     
     
@@ -13,11 +13,11 @@ function (siardata, siarversion = 0, grp = 1:siardata$numgroups,
     if (siardata$numiso > 2 & all(isos == 0)) {
         for (i in 1:(siardata$numiso - 1)) {
             for (j in (i + 1):siardata$numiso) {
-                siarplotdatawrapper(siardata, isos = c(i, j),leg2 = leg)
+                siarplotdatawrapper(siardata, isos = c(i, j),leg2 = leg, color.src = color.src)
             }
         }
     }
     else {
-        siarplotdatawrapper(siardata, siarversion, grp, panel, isos, leg2 = leg)
+        siarplotdatawrapper(siardata, siarversion, grp, panel, isos, leg2 = leg, color.src = color.src)
     }
 }

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -82,7 +82,8 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                   1]^2 + siardata$corrections[i, (2 * isoy) +
                   1]^2)^0.5
                 siaraddcross(x = dx, ex = dex, y = dy, ey = dey,
-                  upch = 15, clr = color.src)
+                  upch = 15, clr = c(seq(1, nrow(siardata$sources)),
+                                     rep(color.src, length(grp))))
             }
         }
         if (!is.null(panel)) {
@@ -113,7 +114,8 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(legloc, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]), col = color.src, bty = "n")
+                pchseq[grp]), col =  clr = c(seq(1, nrow(siardata$sources)),
+                                             rep(color.src, length(grp))), bty = "n")
         }
         if (leg2 == 2) {
             datalabs <- NULL
@@ -131,6 +133,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(0, 0, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]), col = color.src, bty = "n")
+                pchseq[grp]),  clr = c(seq(1, nrow(siardata$sources)),
+                                       rep(color.src, length(grp))), bty = "n")
         }
     }

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -82,8 +82,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                   1]^2 + siardata$corrections[i, (2 * isoy) +
                   1]^2)^0.5
                 siaraddcross(x = dx, ex = dex, y = dy, ey = dey,
-                  upch = 15, clr = c(seq(1, nrow(siardata$sources)),
-                                     rep(color.src, length(grp)))[i])
+                  upch = 15, clr = color.src[1:i])
             }
         }
         if (!is.null(panel)) {

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -1,6 +1,15 @@
 siarplotdatawrapper <-
 function(siardata, siarversion = 0, grp = NULL, panel = NULL,
-        isos = c(1, 2),leg2 = NULL,legloc='topleft') {
+        isos = c(1, 2),leg2 = NULL,legloc='topleft', color.src=NULL) {
+  if(is.null(color.src)){
+    color20 = c("gray0", "red", "green", "blue", "cyan",
+                "magenta", "yellow", "gray", "purple", "darkorange",
+                "gold", "pink", "gray50", "plum", "red4",
+                "green4", "blue4", "cyan4", "magenta4", "cornsilk")
+    color.src = color20
+  }}else{
+    color.src = color.src}
+
         if (!is.null(panel) & is.null(grp)) {
             warning(cat("WARNING. grp set to ALL and panel set to a value.\n Overriding your panel selection and setting to panel=NULL.\n In order to plot all groups on seperate panels please call\n grp=1:siardata$numgroups and panel=1 or panel=c(r,c)\n to specify number of rows and columns"))
             panel <- NULL
@@ -73,7 +82,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                   1]^2 + siardata$corrections[i, (2 * isoy) +
                   1]^2)^0.5
                 siaraddcross(x = dx, ex = dex, y = dy, ey = dey,
-                  upch = 15, clr = i)
+                  upch = 15, clr = color.src)
             }
         }
         if (!is.null(panel)) {
@@ -104,8 +113,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(legloc, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]), col = c(seq(1, nrow(siardata$sources)),
-                rep("grey50", length(grp))), bty = "n")
+                pchseq[grp]), col = color.src, bty = "n")
         }
         if (leg2 == 2) {
             datalabs <- NULL
@@ -123,7 +131,6 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(0, 0, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]), col = c(seq(1, nrow(siardata$sources)),
-                rep("grey50", length(grp))), bty = "n")
+                pchseq[grp]), col = color.src, bty = "n")
         }
     }

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -114,7 +114,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(legloc, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]), col =  clr = c(seq(1, nrow(siardata$sources)),
+                pchseq[grp]), col =  c(seq(1, nrow(siardata$sources)),
                                              rep(color.src, length(grp))), bty = "n")
         }
         if (leg2 == 2) {

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -115,7 +115,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
                 pchseq[grp]), col =  c(seq(1, nrow(siardata$sources)),
-                                             rep(color.src, length(grp))), bty = "n")
+                                             rep("grey50", length(grp))), bty = "n")
         }
         if (leg2 == 2) {
             datalabs <- NULL
@@ -134,6 +134,6 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
                 pchseq[grp]),  clr = c(seq(1, nrow(siardata$sources)),
-                                       rep(color.src, length(grp))), bty = "n")
+                                       rep("grey50", length(grp))), bty = "n")
         }
     }

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -82,7 +82,8 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                   1]^2 + siardata$corrections[i, (2 * isoy) +
                   1]^2)^0.5
                 siaraddcross(x = dx, ex = dex, y = dy, ey = dey,
-                  upch = 15, clr = color.src[1:i])
+                  upch = 15, clr = c(color.src[1:i],
+                                     rep("grey50", length(grp))))
             }
         }
         if (!is.null(panel)) {
@@ -113,7 +114,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(legloc, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]), col =  c(seq(1, nrow(siardata$sources)),
+                pchseq[grp]), col =  c(color.src[1:i],
                                              rep("grey50", length(grp))), bty = "n")
         }
         if (leg2 == 2) {
@@ -132,7 +133,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
             legend(0, 0, legend = c(as.character(siardata$sources[,
                 1]), datalabs), lty = c(rep(1, nrow(siardata$sources)),
                 rep(-1, length(grp))), pch = c(rep(15, nrow(siardata$sources)),
-                pchseq[grp]),  clr = c(seq(1, nrow(siardata$sources)),
+                pchseq[grp]),  clr = c(color.src[1:i],
                                        rep("grey50", length(grp))), bty = "n")
         }
     }

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -82,8 +82,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                   1]^2 + siardata$corrections[i, (2 * isoy) +
                   1]^2)^0.5
                 siaraddcross(x = dx, ex = dex, y = dy, ey = dey,
-                  upch = 15, clr = c(color.src[1:i],
-                                     rep("grey50", length(grp))))
+                  upch = 15, clr = color.src[i])
             }
         }
         if (!is.null(panel)) {

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -7,7 +7,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                 "gold", "pink", "gray50", "plum", "red4",
                 "green4", "blue4", "cyan4", "magenta4", "cornsilk")
     color.src = color20
-  }}else{
+  }else{
     color.src = color.src}
 
         if (!is.null(panel) & is.null(grp)) {

--- a/R/siarplotdatawrapper.R
+++ b/R/siarplotdatawrapper.R
@@ -83,7 +83,7 @@ function(siardata, siarversion = 0, grp = NULL, panel = NULL,
                   1]^2)^0.5
                 siaraddcross(x = dx, ex = dex, y = dy, ey = dey,
                   upch = 15, clr = c(seq(1, nrow(siardata$sources)),
-                                     rep(color.src, length(grp))))
+                                     rep(color.src, length(grp)))[i])
             }
         }
         if (!is.null(panel)) {


### PR DESCRIPTION
- add 'color.src' argument to 'siarplotdatawrapper' and 'siarplotdata' functions
(_I have set 20 different colors as default,_
and the most convenient is that 
# user can set the colors for source items by themselves 
 through the 'color.src' argument in 'siarplotdata( ... , color.src= NULL)' )


- fixed that 'overlap.xypolygon' is not exported by 'namespace:spatstat'
