### PR TITLE
added Return value for 'siarhdrs' function

### DIFF
--- a/R/siarhdrs.R
+++ b/R/siarhdrs.R
@@ -49,7 +49,7 @@ for(i in 1:ncol(siardata$output)) {
     }
 }
 
-print(hdrsummary)
+return(as.data.frame(hdrsummary))
 if(siardata$SIARSOLO==TRUE) cat("Ignore SD columns for siarsolo runs. \n")
 
 if(any(hdrsummary>5)) {

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Stable Isotope Analysis in R - package
 
 Parnell, A.C., Inger R., Bearhop, S. & Jackson, A.L. 2010. Source partioning using stable isotopes: coping with too much variation. PLoS ONE, 5(3), e9672 . [doi](https://doi.org/10.1371/journal.pone.0009672)
 
-Development version 4.2.3.9000 Hotfix 19-July-2018
+Development version 4.2.3.9000 Hotfix 21-July-2018
 * add 'color.src' argument (with 20 different colors set as default) to 'siarplotdatawrapper' and 'siarplotdata' functions, while user can set the colors for source items by themselves. 
-* changed the output in 'siarhdrs' function from c("Low 95% hdr","High 95% hdr","mode","mean") to c("Mean", "SD", "2.5%", "5%", "25%", "50%", "75%", "95", "97.5") as default .
+* changed the output in 'siarhdrs' function from c("Low 95% hdr","High 95% hdr","mode","mean") to c("Mean", "SD", "2.5%", "5%", "25%", "50%", "75%", "95%", "97.5%") as default .
+* add Return value for 'siarhdrs' function. 
 
 Version 4.2.3 20-February-2018
 * bugs from 4.2.2.9000 incorporated.

--- a/man/siarplotdata.Rd
+++ b/man/siarplotdata.Rd
@@ -6,14 +6,14 @@
 }
 \usage{
 siarplotdata(siardata, siarversion = 0, grp=1:siardata$numgroups,panel=NULL,
-isos=c(0,0),leg=1)
+isos=c(0,0),leg=1,color.src=NULL)
 }
 \details{
   Can be called at any time after running \code{\link{siarloaddata}} or when
   running \code{\link{siarmenu}}
 }
 \arguments{
-  \item{siardata}{ A list containing some or all of the following parts: 
+  \item{siardata}{ A list containing some or all of the following parts:
   targets, sources, corrections,
   PATH, TITLE, numgroups, numdata, numsources, numiso, SHOULDRUN, GRAPHSONLY,
   EXIT, and output. For more details
@@ -23,7 +23,7 @@ isos=c(0,0),leg=1)
   rendered on the graph. Default value NULL draws all groups.
   Groups are identified by their own data marker.}
   \item{panel}{A scalar value that determines if the groups of consumer data are
-  to be drawn on the same graph (default=NULL) or on 
+  to be drawn on the same graph (default=NULL) or on
   seperate panels within a single figure. Number of rows and columns of panels
   can be specified by a 2 element vector. Alternatively,
   giving a single value e.g. panel=1 will cause the program to attempt to fit a
@@ -31,13 +31,15 @@ isos=c(0,0),leg=1)
   \item{isos}{A two element vector containing the reference to each isotope
   combination for the x and y axis to be rendered in teh figure.
   Note, only relevant for datasets contianing >2 isotopes. By default, if there
-  are more than two isotopes, seperate figures will be created for 
+  are more than two isotopes, seperate figures will be created for
   all possible combinations of isotopes.}
   \item{leg}{A scalar determining how the legend is to be created. Default leg=1
   prompts the user to locate the legend on each figure.
   leg = 2, puts the legend in a new figure automatically (useful if you want to
-  omit the legend but still want to retain access to the 
+  omit the legend but still want to retain access to the
   information). leg = 0 omits the legend entirely.}
+  \item{color.src}{An option to set the color for source itmes by users themselves. There are 20 different colors set by default as "color.src = NULL".
+  Notes, the length of 'color.src' should be same as the number of "source items"!}
 }
 \author{ Andrew Parnell and Andrew Jackson}
 \keyword{ programming}


### PR DESCRIPTION
**Previous version:**
```
library(siar) # the latest version
...
siarhdrs(model1)
```

**Latest version:** 
(added Return value for 'siarhdrs' function)

- User  can get the return value from siarhdrs(model1) for further analysis or visualization:
```
Results <- siarhdrs(model1)
Results$Mean
Results[1:3,]
barplot(Results[1:3, 1], main = "Barplot of Mean Source Porportions to Group 1"]
```
